### PR TITLE
map, flatMap, fold の実装、および、それを利用するように変更

### DIFF
--- a/src/main/scala/parser/ParseResult.scala
+++ b/src/main/scala/parser/ParseResult.scala
@@ -1,6 +1,14 @@
 package parser
 
-sealed abstract class ParseResult[+T]
+sealed abstract class ParseResult[+T] {
+  def map[U](f: T => U): ParseResult[U] = {
+    this match {
+      case ParseSuccess(r, n) =>
+        ParseSuccess(f(r), n)
+      case _ => this.asInstanceOf[ParseResult[U]]
+    }
+  }
+}
 
 final case class ParseSuccess[T](val result: T, val next: String) extends ParseResult[T]
 

--- a/src/main/scala/parser/ParseResult.scala
+++ b/src/main/scala/parser/ParseResult.scala
@@ -8,6 +8,14 @@ sealed abstract class ParseResult[+T] {
       case _ => this.asInstanceOf[ParseResult[U]]
     }
   }
+
+  def flatMap[U](f: (T, String) => ParseResult[U]): ParseResult[U] = {
+    this match {
+      case ParseSuccess(r, n) => f(r, n)
+      case _ => this.asInstanceOf[ParseResult[U]]
+    }
+  }
+
 }
 
 final case class ParseSuccess[T](val result: T, val next: String) extends ParseResult[T]

--- a/src/main/scala/parser/ParseResult.scala
+++ b/src/main/scala/parser/ParseResult.scala
@@ -16,6 +16,12 @@ sealed abstract class ParseResult[+T] {
     }
   }
 
+  def fold[U](fs: (T, String) => U, ff: String => U): U = {
+    this match {
+      case ParseSuccess(r, n) => fs(r, n)
+      case ParseFailure(m) => ff(m)
+    }
+  }
 }
 
 final case class ParseSuccess[T](val result: T, val next: String) extends ParseResult[T]

--- a/src/main/scala/parser/Parser.scala
+++ b/src/main/scala/parser/Parser.scala
@@ -74,20 +74,8 @@ class Parser[T](parser: String => ParseResult[T]) {
     * @tparam U
     * @return parser instance
     */
-  def seq[U](parser: => Parser[U]): Parser[(T, U)] = Parser {
-    target =>
-      this.parse(target) match {
-        case ParseSuccess(r1, n2) =>
-          parser.parse(n2) match {
-            case ParseSuccess(r2, n2) =>
-              ParseSuccess((r1, r2), n2)
-            case failure@ParseFailure(_) =>
-              failure
-          }
-        case failure@ParseFailure(_) =>
-          failure
-      }
-  }
+  def seq[U](parser: => Parser[U]): Parser[(T, U)] =
+    Parser(parse(_).flatMap((r1, n1) => parser.parse(n1).map((r1, _))))
 
   /** convert parse result
     *

--- a/src/main/scala/parser/Parser.scala
+++ b/src/main/scala/parser/Parser.scala
@@ -95,15 +95,7 @@ class Parser[T](parser: String => ParseResult[T]) {
     * @tparam U convert result type
     * @return parser instance
     */
-  def map[U](f: T => U): Parser[U] = Parser {
-    target =>
-      this.parse(target) match {
-        case ParseSuccess(r, n) =>
-          ParseSuccess(f(r), n)
-        case failure@ParseFailure(_) =>
-          failure
-      }
-  }
+  def map[U](f: T => U): Parser[U] = Parser(parse(_).map(f))
 
   /** end parser.
     * After parse, if next string is empty, return Success.

--- a/src/test/scala/parser/ParserSpec.scala
+++ b/src/test/scala/parser/ParserSpec.scala
@@ -54,6 +54,28 @@ class ParserSpec extends WordSpec with Matchers {
   }
 
   "seq parser" should {
+    "do eager evaluation" in {
+      val changedValue = 1
+      var changeValue = 0
+      val evaluatedFun: String => ParseResult[String] = {
+        _ =>
+          changeValue = changedValue
+          ParseSuccess("", "")
+      }
+      Parser("a").seq(Parser(evaluatedFun)).parse("aa")
+      changeValue shouldBe changedValue
+    }
+    "delay evaluation" in {
+      val expectedValue = 0
+      var nonChangeValue = expectedValue
+      val nonEvaluatedFun: String => ParseResult[String] = {
+        _ =>
+          nonChangeValue = 1
+          ParseSuccess("", "")
+      }
+      Parser("b").seq(Parser(nonEvaluatedFun)).parse("aa")
+      nonChangeValue shouldBe expectedValue
+    }
     "all success" in {
       Parser("a").seq(Parser("b")).parse("ab") shouldBe
         ParseSuccess(("a", "b"), "")

--- a/src/test/scala/parser/ParserSpec.scala
+++ b/src/test/scala/parser/ParserSpec.scala
@@ -37,6 +37,29 @@ class ParserSpec extends WordSpec with Matchers {
   }
 
   "or parser" should {
+    "do eager evaluation" in {
+      val changedValue = 1
+      var changeValue = 0
+      val evaluatedFun: String => ParseResult[String] = {
+        _ =>
+          changeValue = changedValue
+          ParseSuccess("", "")
+      }
+      Parser("b").or(Parser(evaluatedFun)).parse("aa")
+      changeValue shouldBe changedValue
+    }
+    "delay evaluation" in {
+      val expectedValue = 0
+      var nonChangeValue = expectedValue
+      val nonEvaluatedFun: String => ParseResult[String] = {
+        _ =>
+          nonChangeValue = 1
+          ParseSuccess("", "")
+      }
+      Parser("a").or(Parser(nonEvaluatedFun)).parse("aa")
+      nonChangeValue shouldBe expectedValue
+    }
+
     "match first parser" in {
       Parser("a").or(Parser("b")).parse("aa") shouldBe
         ParseSuccess("a", "a")


### PR DESCRIPTION
以下のように変更
ただし、for内包表記は利用していない
（現在の実装では動かないため）
- ParseResult内 map, flatMap, fold の実装
- Parser内 map, flatMap, fold を利用するように変更
- or, andについて遅延評価が効いてるか気になったため、そのテストを追加